### PR TITLE
Replace landing page with badminton operations management app

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,102 +1,738 @@
 <!DOCTYPE html>
 <html lang="ko">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>배드민턴 운영용 사이트</title>
+  <style>
+    :root {
+      --bg: #f8fafc;
+      --card: #ffffff;
+      --text: #0f172a;
+      --muted: #64748b;
+      --border: #e2e8f0;
+      --border-strong: #0f172a;
+      --soft: #f1f5f9;
+      --soft-2: #e2e8f0;
+      --accent: #111827;
+      --danger: #dc2626;
+      --shadow: 0 1px 3px rgba(15, 23, 42, 0.08), 0 1px 2px rgba(15, 23, 42, 0.04);
+      --radius: 18px;
+    }
 
-    <meta name="description" content="HY 웹 개발 포트폴리오 - Java와 Spring Framework 기반 금융 및 공공 기관 시스템 개발 경험 소개." />
-    <meta name="keywords" content="웹 개발, Java, Spring Framework, 금융 시스템, 공공 기관, 포트폴리오, 백엔드 개발자" />
-    <meta name="author" content="장하영" />
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: Arial, "Apple SD Gothic Neo", "Malgun Gothic", sans-serif;
+      background: var(--bg);
+      color: var(--text);
+    }
 
-    <meta property="og:title" content="HY's Web Development Portfolio" />
-    <meta property="og:description" content="Java와 Spring Framework로 구축된 금융 및 공공 기관 시스템 개발 경험을 담은 포트폴리오." />
-    <meta property="og:image" content="https://hyjang0816.github.io/img/luca-bravo-XJXWbfSo2f0-unsplash.jpg" />
-    <meta property="og:url" content="https://hyjang0816.github.io" />
-    <meta property="og:type" content="website" />
+    .page {
+      max-width: 1400px;
+      margin: 0 auto;
+      padding: 20px;
+    }
 
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="HY's Web Development Portfolio" />
-    <meta name="twitter:description" content="Java와 Spring Framework로 구축된 금융 및 공공 기관 시스템 개발 경험을 담은 포트폴리오." />
-    <meta name="twitter:image" content="https://hyjang0816.github.io/img/luca-bravo-XJXWbfSo2f0-unsplash.jpg" />
+    .topbar {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 16px;
+      flex-wrap: wrap;
+      margin-bottom: 20px;
+    }
 
-    <title>HY's Portfolio</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;700&display=swap" rel="stylesheet" />
-    <link rel="stylesheet" href="/css/style.css?ver=1.0" />
-  </head>
-  <body>
+    h1 {
+      margin: 0;
+      font-size: 32px;
+      line-height: 1.2;
+    }
 
-    <header>
-      <h1>HY's Portfolio</h1>
-      <nav>
-        <ul>
-          <li><a href="#introduction">소개</a></li>
-          <li><a href="#section1">증권투자수탁</a></li>
-          <li><a href="#section2">공제회 유지보수</a></li>
-        </ul>
-      </nav>
-    </header>
+    .subtitle {
+      color: var(--muted);
+      margin-top: 8px;
+      font-size: 14px;
+    }
 
-    <!-- 자기소개 섹션 -->
-    <section id="introduction">
+    .actions { display: flex; gap: 10px; flex-wrap: wrap; }
+
+    .btn {
+      border: 1px solid var(--border);
+      background: var(--card);
+      color: var(--text);
+      padding: 10px 14px;
+      border-radius: 14px;
+      cursor: pointer;
+      font-size: 14px;
+      transition: 0.15s ease;
+    }
+    .btn:hover { background: #f8fafc; }
+    .btn.primary {
+      background: var(--accent);
+      color: white;
+      border-color: var(--accent);
+    }
+    .btn.icon {
+      width: 38px;
+      height: 38px;
+      padding: 0;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 16px;
+    }
+
+    .save-message {
+      color: var(--muted);
+      font-size: 13px;
+      margin-bottom: 14px;
+      min-height: 18px;
+    }
+
+    .stats {
+      display: grid;
+      grid-template-columns: repeat(5, minmax(0, 1fr));
+      gap: 14px;
+      margin-bottom: 20px;
+    }
+
+    .card {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 22px;
+      box-shadow: var(--shadow);
+    }
+
+    .stat-card {
+      padding: 18px;
+    }
+    .stat-label { color: var(--muted); font-size: 13px; margin-bottom: 6px; }
+    .stat-value { font-size: 28px; font-weight: 700; }
+
+    .main {
+      display: grid;
+      grid-template-columns: 1.45fr 0.95fr;
+      gap: 22px;
+    }
+
+    .section-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 12px;
+      flex-wrap: wrap;
+    }
+
+    .section-title {
+      font-size: 22px;
+      font-weight: 700;
+    }
+
+    .badge {
+      background: var(--soft);
+      color: var(--text);
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      padding: 7px 12px;
+      font-size: 13px;
+      white-space: nowrap;
+    }
+
+    .court-list, .participant-list {
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+    }
+
+    .court-card-header, .panel-header {
+      padding: 18px 18px 0 18px;
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .court-card-body, .panel-body {
+      padding: 18px;
+    }
+
+    .court-subtitle, .helper {
+      color: var(--muted);
+      font-size: 13px;
+      margin-top: 6px;
+    }
+
+    .court-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .slot {
+      border: 1px solid var(--border);
+      background: white;
+      border-radius: 16px;
+      min-height: 58px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+      padding: 12px 14px;
+      cursor: pointer;
+      transition: 0.15s ease;
+    }
+    .slot:hover { background: #f8fafc; }
+    .slot.active {
+      border-color: var(--border-strong);
+      box-shadow: 0 0 0 3px rgba(15, 23, 42, 0.08);
+    }
+    .slot.empty { color: #94a3b8; }
+    .slot-player { font-weight: 600; }
+    .slot-remove {
+      color: #94a3b8;
+      font-size: 16px;
+      cursor: pointer;
+      padding: 4px;
+    }
+    .slot-remove:hover { color: var(--danger); }
+
+    .input-row {
+      display: grid;
+      grid-template-columns: 1fr auto;
+      gap: 10px;
+    }
+
+    textarea, input {
+      width: 100%;
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      padding: 12px 14px;
+      font-size: 14px;
+      font-family: inherit;
+      outline: none;
+      background: white;
+    }
+    textarea:focus, input:focus { border-color: #94a3b8; }
+
+    .participant-item {
+      display: grid;
+      grid-template-columns: 1fr auto auto auto;
+      gap: 8px;
+      align-items: center;
+    }
+
+    .participant-main {
+      border: 1px solid var(--border);
+      background: white;
+      border-radius: 16px;
+      padding: 12px 14px;
+      cursor: pointer;
+      transition: 0.15s ease;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 10px;
+      min-width: 0;
+    }
+    .participant-main:hover { background: #f8fafc; }
+    .participant-main.selected {
+      background: var(--accent);
+      color: white;
+      border-color: var(--accent);
+    }
+    .participant-main.placed:not(.selected) {
+      background: #f1f5f9;
+      color: #64748b;
+    }
+    .participant-meta { min-width: 0; }
+    .participant-count {
+      font-size: 12px;
+      opacity: 0.8;
+      margin-bottom: 4px;
+    }
+    .participant-name {
+      font-weight: 700;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .placed-badge {
+      font-size: 12px;
+      border: 1px solid var(--border);
+      background: white;
+      color: var(--text);
+      border-radius: 999px;
+      padding: 5px 10px;
+      white-space: nowrap;
+    }
+    .participant-main.selected .placed-badge {
+      background: rgba(255,255,255,0.12);
+      color: white;
+      border-color: rgba(255,255,255,0.25);
+    }
+
+    .empty-text {
+      color: var(--muted);
+      font-size: 14px;
+    }
+
+    @media (max-width: 1100px) {
+      .stats { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .main { grid-template-columns: 1fr; }
+    }
+
+    @media (max-width: 700px) {
+      .stats { grid-template-columns: 1fr; }
+      .court-grid { grid-template-columns: 1fr; }
+      .participant-item { grid-template-columns: 1fr auto auto auto; }
+      h1 { font-size: 28px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <div class="topbar">
       <div>
-        <h2>자기소개</h2>
-        <p>저는 다양한 시스템 개발 및 유지보수 프로젝트를 통해 쌓은 경험과 전문성을 바탕으로 안정적이고 효율적인 시스템 운영을 목표로 하는 웹 개발자입니다.</p>
-        <p>농협 차세대 증권투자수탁시스템과 건설근로자공제회 통합유지보수 프로젝트에서 다양한 기술과 업무 요구사항에 맞춰 유연하게 대응할 수 있는 역량을 키웠습니다.</p>
-        <p>저는 항상 시스템의 성능과 안정성을 최우선으로 고려하며, 사용자 경험을 개선하는 데 주력합니다. 다양한 기술 스택을 활용하여 문제를 해결하고, 지속적인 성장을 추구하고 있습니다.</p>
+        <h1>배드민턴 운영용 사이트</h1>
+        <div class="subtitle">라운드 없이 코트별 게임 기준으로 운영합니다. 코트를 편성한 뒤 게임 종료를 누르면 참여 횟수가 누적되고 코트가 비워집니다.</div>
       </div>
-      <div>
-        <h2>주요 업무 및 성과</h2>
-        <ul>
-          <li>퇴직공제 시스템 개선: 성립신고 중복 신청 방지 및 근로내역 직종 변경 기능 개발</li>
-          <li>하나로 시스템 개발: 전자카드 로그인 및 계좌 연동, 미상환 대부금 자동 상환 및 승인 처리 기능 개발</li>
-          <li>기능플러스 시스템 개선: 나이스 본인인증 기능 개선, 근로복지공단 고용보험 대용량 및 실시간 연계 개발, 등급증명서 발급 수수료 결제 기능 개발, 보유증명서 발급 기능 개선 및 등급 산정 기준 조정</li>
-          <li>개인정보접속기록관리 시스템 구축: Apache Cassandra 연동, 개인정보 이력 관리 및 엑셀 다운로드 기능 개발</li>
-        </ul>
-        <p><strong>사용 기술:</strong> MSSQL, Apache Cassandra, SVN, Java, Javascript, JQuery, Spring Framework</p>
+      <div class="actions">
+        <button class="btn" id="clearCourtsBtn">코트 비우기</button>
+        <button class="btn" id="resetAllBtn">전체 초기화</button>
+        <button class="btn primary" id="completeGameBtn">게임 종료 + 참여횟수 반영</button>
       </div>
-    </section>
+    </div>
 
-    <!-- 프로젝트 섹션 1: 농협 차세대 증권투자수탁시스템 -->
-    <section id="section1">
-      <div>
-        <h2>농협 차세대 증권투자수탁시스템</h2>
-        <p>계좌 조회 및 채권/펀드 조회 화면 개발</p>
-        <p>AS-IS -> TO-BE 화면 전환, 사용자 경험 향상</p>
-        <p>DBIO 로직을 개발하여 데이터 처리 성능 강화</p>
-        <p><strong>사용 기술:</strong> Oracle, ProFrame, XPlatform, Javascript</p>
-      </div>
-    </section>
+    <div class="save-message" id="saveMessage"></div>
 
-    <!-- 프로젝트 섹션 2: 건설근로자공제회 통합유지보수 -->
-    <section id="section2">
-      <div>
-        <h2>건설근로자공제회 통합유지보수</h2>
-        <h3>퇴직공제 시스템</h3>
-        <p>성립신고 중복 신청 방지 및 직종 변경 기능 개발</p>
-        <p><strong>사용 기술:</strong> Java, Spring Framework, MSSQL</p>
-        <hr/>
-        <h3>하나로 시스템</h3>
-        <p>전자카드 계좌 연동, 미상환 대부금 자동 상환 및 승인 처리 개발</p>
-        <hr/>
-        <h3>기능플러스 시스템</h3>
-        <p>나이스 본인인증 기능 개선 및 보유증명서 발급 기능 개발</p>
-        <p>근로복지공단 고용보험 대용량 및 실시간 연계</p>
-        <p>기능등급 산정 기준 조정</p>
-        <p>등급증명서 발급 수수료결제 기능 개발</p>
-        <p><strong>사용 기술:</strong> Java, Spring Framework, MSSQL, Javascript, Jquey</p>
-        <hr/>
-        <h3>개인정보접속기록관리 시스템</h3>
-        <p>Apache Cassandra 연동 및 고객사 개인정보 처리 시스템별 개인정보 접근 이력 관리</p>
-        <p>엑셀 다운로드 공통 팝업 기능 개발</p>
-        <p><strong>사용 기술:</strong> Java, Spring Framework, MSSQL, Apache Cassandra, Javascript, Jquery</p>
-      </div>
-    </section>
+    <div class="stats" id="stats"></div>
 
-    <!-- 푸터 -->
-    <footer>
-      <p>&copy; 2024 HY's Portfolio</p>
-    </footer>
-  </body>
+    <div class="main">
+      <div>
+        <div class="section-header">
+          <div class="section-title">코트 편성</div>
+          <div style="display:flex; gap:10px; align-items:center; flex-wrap:wrap;">
+            <div class="badge" id="activeSlotBadge">자리를 먼저 선택하세요</div>
+            <button class="btn" id="recommendPlacementBtn">자동 추천 배치</button>
+            <button class="btn" id="addCourtBtn">코트 추가</button>
+          </div>
+        </div>
+        <div class="court-list" id="courtList"></div>
+      </div>
+
+      <div>
+        <div class="card" style="margin-bottom:14px;">
+          <div class="panel-header">
+            <div>
+              <div class="section-title" style="font-size:20px;">참석자 입력</div>
+            </div>
+          </div>
+          <div class="panel-body">
+            <label for="playerInput" style="display:block; font-size:14px; margin-bottom:8px;">이름 입력</label>
+            <div class="input-row">
+              <textarea id="playerInput" rows="3" placeholder="쉼표 또는 줄바꿈으로 여러 명 입력"></textarea>
+              <button class="btn" id="addParticipantsBtn">추가</button>
+            </div>
+            <div class="helper">새로고침해도 데이터가 브라우저에 저장됩니다. 참여 횟수는 게임 종료 버튼으로 자동 반영하거나, 목록에서 직접 조정할 수 있습니다.</div>
+          </div>
+        </div>
+
+        <div class="card">
+          <div class="panel-header">
+            <div>
+              <div class="section-title" style="font-size:20px;">참석자 목록</div>
+              <div class="helper">참여 횟수가 적은 순으로 자동 정렬되며, 자동 추천 배치 버튼으로 빈 자리를 빠르게 채울 수 있습니다.</div>
+            </div>
+          </div>
+          <div class="panel-body">
+            <div class="participant-list" id="participantList"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const STORAGE_KEY = "badminton-ops-site-html-v1";
+
+    function uid() {
+      if (window.crypto && crypto.randomUUID) return crypto.randomUUID();
+      return "id-" + Math.random().toString(36).slice(2) + Date.now().toString(36);
+    }
+
+    function createCourt() {
+      return { id: uid(), players: ["", "", "", ""] };
+    }
+
+    function createInitialState() {
+      return {
+        courts: [createCourt()],
+        participants: [],
+        participationCounts: {},
+      };
+    }
+
+    let data = loadData();
+    let activeSlot = null;
+    let selectedParticipant = null;
+    let saveTimer = null;
+
+    function loadData() {
+      try {
+        const saved = localStorage.getItem(STORAGE_KEY);
+        if (saved) return JSON.parse(saved);
+      } catch (e) {}
+      return createInitialState();
+    }
+
+    function persist(next) {
+      data = next;
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+      flashSaved();
+      render();
+    }
+
+    function flashSaved() {
+      const el = document.getElementById("saveMessage");
+      el.textContent = "저장됨";
+      clearTimeout(saveTimer);
+      saveTimer = setTimeout(() => {
+        el.textContent = "";
+      }, 1000);
+    }
+
+    function getPlacedPlayers() {
+      return data.courts.flatMap(court => court.players).filter(Boolean);
+    }
+
+    function getSortedParticipants() {
+      const placedSet = new Set(getPlacedPlayers());
+      return data.participants
+        .map((name, index) => ({
+          name,
+          index,
+          key: `${name}__${index}`,
+          count: data.participationCounts?.[name] || 0,
+          isPlaced: placedSet.has(name),
+        }))
+        .sort((a, b) => {
+          if (a.count !== b.count) return a.count - b.count;
+          if (a.isPlaced !== b.isPlaced) return Number(a.isPlaced) - Number(b.isPlaced);
+          return a.index - b.index;
+        });
+    }
+
+    function getSummary() {
+      const placedPlayers = getPlacedPlayers();
+      const courts = data.courts.length;
+      const participants = data.participants.length;
+      const assigned = placedPlayers.length;
+      const unassigned = Math.max(participants - assigned, 0);
+      const emptySlots = data.courts.reduce((sum, court) => sum + court.players.filter(p => !p).length, 0);
+      return { courts, participants, assigned, unassigned, emptySlots };
+    }
+
+    function addParticipants() {
+      const input = document.getElementById("playerInput");
+      const names = input.value
+        .split(/\n|,/)
+        .map(name => name.trim())
+        .filter(Boolean);
+      if (!names.length) return;
+      persist({
+        ...data,
+        participants: [...data.participants, ...names],
+      });
+      input.value = "";
+    }
+
+    function addCourt() {
+      persist({
+        ...data,
+        courts: [...data.courts, createCourt()],
+      });
+    }
+
+    function recommendPlacement() {
+      const candidates = getSortedParticipants().filter(participant => !participant.isPlaced);
+      if (!candidates.length) return;
+
+      let candidateIndex = 0;
+      const nextCourts = data.courts.map(court => {
+        const nextPlayers = [...court.players];
+        for (let i = 0; i < nextPlayers.length; i += 1) {
+          if (nextPlayers[i]) continue;
+          if (candidateIndex >= candidates.length) break;
+          nextPlayers[i] = candidates[candidateIndex].name;
+          candidateIndex += 1;
+        }
+        return { ...court, players: nextPlayers };
+      });
+
+      activeSlot = null;
+      selectedParticipant = null;
+      persist({
+        ...data,
+        courts: nextCourts,
+      });
+    }
+
+    function removeCourt(courtId) {
+      const nextCourts = data.courts.length === 1 ? data.courts : data.courts.filter(c => c.id !== courtId);
+      if (activeSlot && activeSlot.courtId === courtId) activeSlot = null;
+      persist({ ...data, courts: nextCourts });
+    }
+
+    function selectSlot(courtId, slotIndex) {
+      activeSlot = { courtId, slotIndex };
+      render();
+    }
+
+    function assignParticipant(name, key) {
+      if (!activeSlot) return;
+      const clearedCourts = data.courts.map(court => ({
+        ...court,
+        players: court.players.map(p => p === name ? "" : p),
+      }));
+
+      const nextCourts = clearedCourts.map(court => {
+        if (court.id !== activeSlot.courtId) return court;
+        const nextPlayers = [...court.players];
+        nextPlayers[activeSlot.slotIndex] = name;
+        return { ...court, players: nextPlayers };
+      });
+
+      selectedParticipant = key;
+      persist({ ...data, courts: nextCourts });
+    }
+
+    function removePlayerFromCourt(courtId, slotIndex) {
+      persist({
+        ...data,
+        courts: data.courts.map(court => {
+          if (court.id !== courtId) return court;
+          const nextPlayers = [...court.players];
+          nextPlayers[slotIndex] = "";
+          return { ...court, players: nextPlayers };
+        })
+      });
+    }
+
+    function removeParticipant(targetName, targetIndex) {
+      persist({
+        ...data,
+        participants: data.participants.filter((name, index) => !(name === targetName && index === targetIndex)),
+        courts: data.courts.map(court => ({
+          ...court,
+          players: court.players.map(p => p === targetName ? "" : p),
+        }))
+      });
+    }
+
+    function increaseCount(name) {
+      persist({
+        ...data,
+        participationCounts: {
+          ...data.participationCounts,
+          [name]: (data.participationCounts?.[name] || 0) + 1,
+        }
+      });
+    }
+
+    function decreaseCount(name) {
+      const current = data.participationCounts?.[name] || 0;
+      persist({
+        ...data,
+        participationCounts: {
+          ...data.participationCounts,
+          [name]: Math.max(current - 1, 0),
+        }
+      });
+    }
+
+    function completeCurrentGame() {
+      const uniquePlayed = Array.from(new Set(getPlacedPlayers()));
+      const nextCounts = { ...(data.participationCounts || {}) };
+      uniquePlayed.forEach(name => {
+        nextCounts[name] = (nextCounts[name] || 0) + 1;
+      });
+
+      activeSlot = null;
+      selectedParticipant = null;
+      persist({
+        ...data,
+        participationCounts: nextCounts,
+        courts: data.courts.map(court => ({ ...court, players: ["", "", "", ""] }))
+      });
+    }
+
+    function clearCourts() {
+      activeSlot = null;
+      selectedParticipant = null;
+      persist({
+        ...data,
+        courts: data.courts.map(court => ({ ...court, players: ["", "", "", ""] }))
+      });
+    }
+
+    function resetAll() {
+      data = createInitialState();
+      activeSlot = null;
+      selectedParticipant = null;
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+      document.getElementById("playerInput").value = "";
+      flashSaved();
+      render();
+    }
+
+    function renderStats() {
+      const stats = getSummary();
+      const container = document.getElementById("stats");
+      const items = [
+        ["코트 수", stats.courts],
+        ["참석자", stats.participants],
+        ["배치 완료", stats.assigned],
+        ["미배치", stats.unassigned],
+        ["빈 자리", stats.emptySlots],
+      ];
+
+      container.innerHTML = items.map(([label, value]) => `
+        <div class="card stat-card">
+          <div class="stat-label">${label}</div>
+          <div class="stat-value">${value}</div>
+        </div>
+      `).join("");
+    }
+
+    function renderCourts() {
+      const list = document.getElementById("courtList");
+      list.innerHTML = data.courts.map((court, index) => {
+        const filled = court.players.filter(Boolean).length;
+        const slots = court.players.map((player, slotIndex) => {
+          const isActive = activeSlot && activeSlot.courtId === court.id && activeSlot.slotIndex === slotIndex;
+          return `
+            <button class="slot ${isActive ? "active" : ""} ${player ? "" : "empty"}" data-court-id="${court.id}" data-slot-index="${slotIndex}">
+              <span class="${player ? "slot-player" : ""}">${player || "빈 자리"}</span>
+              ${player ? `<span class="slot-remove" data-remove-court-id="${court.id}" data-remove-slot-index="${slotIndex}">✕</span>` : `<span style="font-size:12px;color:#cbd5e1;">선택</span>`}
+            </button>
+          `;
+        }).join("");
+
+        return `
+          <div class="card">
+            <div class="court-card-header">
+              <div>
+                <div class="section-title" style="font-size:20px;">코트 ${index + 1}</div>
+                <div class="court-subtitle">복식 · 최대 4명</div>
+              </div>
+              <div style="display:flex; gap:10px; align-items:center;">
+                <div class="badge">${filled}/4</div>
+                <button class="btn" data-delete-court-id="${court.id}">삭제</button>
+              </div>
+            </div>
+            <div class="court-card-body">
+              <div class="court-grid">${slots}</div>
+            </div>
+          </div>
+        `;
+      }).join("");
+
+      list.querySelectorAll("[data-court-id][data-slot-index]").forEach(btn => {
+        btn.addEventListener("click", (e) => {
+          if (e.target.closest("[data-remove-court-id]")) return;
+          selectSlot(btn.dataset.courtId, Number(btn.dataset.slotIndex));
+        });
+      });
+
+      list.querySelectorAll("[data-remove-court-id]").forEach(btn => {
+        btn.addEventListener("click", (e) => {
+          e.stopPropagation();
+          removePlayerFromCourt(btn.dataset.removeCourtId, Number(btn.dataset.removeSlotIndex));
+        });
+      });
+
+      list.querySelectorAll("[data-delete-court-id]").forEach(btn => {
+        btn.addEventListener("click", () => removeCourt(btn.dataset.deleteCourtId));
+      });
+    }
+
+    function renderParticipants() {
+      const list = document.getElementById("participantList");
+      if (!data.participants.length) {
+        list.innerHTML = '<div class="empty-text">참석자 이름을 먼저 입력해 주세요.</div>';
+        return;
+      }
+
+      list.innerHTML = getSortedParticipants().map(({ name, index, key, isPlaced, count }) => `
+        <div class="participant-item">
+          <button class="participant-main ${selectedParticipant === key ? "selected" : ""} ${isPlaced ? "placed" : ""}" data-participant-name="${escapeHtml(name)}" data-participant-key="${escapeHtml(key)}">
+            <div class="participant-meta">
+              <div class="participant-count">참여 ${count}회</div>
+              <div class="participant-name">${escapeHtml(name)}</div>
+            </div>
+            ${isPlaced ? '<span class="placed-badge">배치됨</span>' : ''}
+          </button>
+          <button class="btn icon" data-decrease-name="${escapeHtml(name)}">−</button>
+          <button class="btn icon" data-increase-name="${escapeHtml(name)}">＋</button>
+          <button class="btn icon" data-remove-name="${escapeHtml(name)}" data-remove-index="${index}">✕</button>
+        </div>
+      `).join("");
+
+      list.querySelectorAll("[data-participant-name]").forEach(btn => {
+        btn.addEventListener("click", () => assignParticipant(btn.dataset.participantName, btn.dataset.participantKey));
+      });
+      list.querySelectorAll("[data-decrease-name]").forEach(btn => {
+        btn.addEventListener("click", () => decreaseCount(btn.dataset.decreaseName));
+      });
+      list.querySelectorAll("[data-increase-name]").forEach(btn => {
+        btn.addEventListener("click", () => increaseCount(btn.dataset.increaseName));
+      });
+      list.querySelectorAll("[data-remove-name]").forEach(btn => {
+        btn.addEventListener("click", () => removeParticipant(btn.dataset.removeName, Number(btn.dataset.removeIndex)));
+      });
+    }
+
+    function renderActiveSlotBadge() {
+      const badge = document.getElementById("activeSlotBadge");
+      if (!activeSlot) {
+        badge.textContent = "자리를 먼저 선택하세요";
+        return;
+      }
+      const courtIndex = data.courts.findIndex(c => c.id === activeSlot.courtId);
+      badge.textContent = `선택된 자리: 코트 ${courtIndex + 1} / ${activeSlot.slotIndex + 1}번`;
+    }
+
+    function render() {
+      renderStats();
+      renderCourts();
+      renderParticipants();
+      renderActiveSlotBadge();
+    }
+
+    function escapeHtml(value) {
+      return String(value)
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;")
+        .replaceAll('"', "&quot;")
+        .replaceAll("'", "&#39;");
+    }
+
+    document.getElementById("addParticipantsBtn").addEventListener("click", addParticipants);
+    document.getElementById("addCourtBtn").addEventListener("click", addCourt);
+    document.getElementById("recommendPlacementBtn").addEventListener("click", recommendPlacement);
+    document.getElementById("completeGameBtn").addEventListener("click", completeCurrentGame);
+    document.getElementById("clearCourtsBtn").addEventListener("click", clearCourts);
+    document.getElementById("resetAllBtn").addEventListener("click", resetAll);
+    document.getElementById("playerInput").addEventListener("keydown", (e) => {
+      if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) addParticipants();
+    });
+
+    render();
+  </script>
+</body>
 </html>


### PR DESCRIPTION
### Motivation
- Replace the existing portfolio landing page with a focused single-page app to manage badminton sessions (court assignment, participant tracking, and simple operations).
- Provide an offline-friendly UI that persists state in the browser and supports quick operations like recommended placement and marking game completion.

### Description
- Replaced `index.html` entirely with a self-contained single-page app that includes styles, markup and JavaScript for court/slot assignment, participant management, participation count tracking, and `localStorage` persistence.
- Implemented UI controls for adding/removing courts, adding participants (comma/newline separated), selecting slots, assigning/removing players, automatic recommended placement, clearing courts, completing a game (increments participation counts), and per-participant count adjustments.
- Added runtime helpers: `uid()`, state load/persist functions, rendering helpers, and HTML-escaping utilities to prevent injection.
- Committed the change to the repo (commit short id `87d3002`).

### Testing
- Launched a local static server with `python3 -m http.server 8000` to serve the updated page, and the server started successfully. 
- Rendered the page and captured a full-page screenshot using Playwright (`artifacts/badminton-ui.png`), which completed successfully. 
- Verified repository status and created a commit for the updated `index.html` successfully. 
- Attempted `git push` but it failed due to no configured remote (automated push step failed with `No configured push destination`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afa0e070b0832db4002707e84a11d5)