### PR TITLE
Add social sharing metadata to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,21 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>배드민턴 운영용 사이트</title>
+  <meta name="description" content="배드민턴 코트 배치, 참석자 관리, 참여 횟수 누적을 한 번에 처리하는 운영용 사이트입니다." />
+  <meta name="theme-color" content="#0f172a" />
+  <link rel="canonical" href="https://hyjang0816.github.io/" />
+  <meta property="og:type" content="website" />
+  <meta property="og:locale" content="ko_KR" />
+  <meta property="og:site_name" content="배드민턴 운영용 사이트" />
+  <meta property="og:title" content="배드민턴 운영용 사이트" />
+  <meta property="og:description" content="배드민턴 코트 배치, 참석자 관리, 참여 횟수 누적을 한 번에 처리하는 운영용 사이트입니다." />
+  <meta property="og:url" content="https://hyjang0816.github.io/" />
+  <meta property="og:image" content="https://hyjang0816.github.io/img/leif-christoph-gottwald-iM8dxccK1sY-unsplash.jpg" />
+  <meta property="og:image:alt" content="배드민턴 운영용 사이트 링크 공유용 대표 이미지" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="배드민턴 운영용 사이트" />
+  <meta name="twitter:description" content="배드민턴 코트 배치, 참석자 관리, 참여 횟수 누적을 한 번에 처리하는 운영용 사이트입니다." />
+  <meta name="twitter:image" content="https://hyjang0816.github.io/img/leif-christoph-gottwald-iM8dxccK1sY-unsplash.jpg" />
   <style>
     :root {
       --bg: #f8fafc;


### PR DESCRIPTION
### Motivation
- Ensure shared links show a meaningful title, description, and representative image across social platforms and chat apps.
- Use the repository's GitHub Pages URL and an existing asset so previews render without adding new hosted resources.

### Description
- Add `description` and `theme-color` meta tags to the `<head>` of `index.html`.
- Add a canonical `<link>` pointing to `https://hyjang0816.github.io/` and Open Graph tags `og:type`, `og:locale`, `og:site_name`, `og:title`, `og:description`, `og:url`, `og:image`, and `og:image:alt` to `index.html`.
- Add Twitter Card tags `twitter:card`, `twitter:title`, `twitter:description`, and `twitter:image` that reference the existing asset at `https://hyjang0816.github.io/img/leif-christoph-gottwald-iM8dxccK1sY-unsplash.jpg`.
- Changes are limited to the HTML head and do not modify site behavior or JavaScript logic.

### Testing
- Ran a Python metadata validation script that asserted required `<meta>` entries and the canonical `link` in `index.html`, and the check passed.
- Verified the referenced preview image exists with `test -f img/leif-christoph-gottwald-iM8dxccK1sY-unsplash.jpg`, and the check passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bcac86800c832d8196601b90eda7ef)