### PR TITLE
Update social share preview to badminton image

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,12 +13,12 @@
   <meta property="og:title" content="배드민턴 운영용 사이트" />
   <meta property="og:description" content="배드민턴 코트 배치, 참석자 관리, 참여 횟수 누적을 한 번에 처리하는 운영용 사이트입니다." />
   <meta property="og:url" content="https://hyjang0816.github.io/" />
-  <meta property="og:image" content="https://hyjang0816.github.io/img/leif-christoph-gottwald-iM8dxccK1sY-unsplash.jpg" />
-  <meta property="og:image:alt" content="배드민턴 운영용 사이트 링크 공유용 대표 이미지" />
+  <meta property="og:image" content="https://cdn.pixabay.com/photo/2020/10/04/13/00/shuttlecocks-5626284_1280.jpg" />
+  <meta property="og:image:alt" content="컬러 셔틀콕이 놓인 배드민턴 라켓 이미지" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="배드민턴 운영용 사이트" />
   <meta name="twitter:description" content="배드민턴 코트 배치, 참석자 관리, 참여 횟수 누적을 한 번에 처리하는 운영용 사이트입니다." />
-  <meta name="twitter:image" content="https://hyjang0816.github.io/img/leif-christoph-gottwald-iM8dxccK1sY-unsplash.jpg" />
+  <meta name="twitter:image" content="https://cdn.pixabay.com/photo/2020/10/04/13/00/shuttlecocks-5626284_1280.jpg" />
   <style>
     :root {
       --bg: #f8fafc;


### PR DESCRIPTION
### Motivation
- Replace the current local preview image with a publicly hosted badminton photo and update its alt text so link previews better represent the site.

### Description
- Updated Open Graph `og:image` and `og:image:alt`, and the Twitter card `twitter:image` in `index.html` to point to a badminton photo hosted on Pixabay.

### Testing
- Inspected `index.html` and confirmed the three meta tags were updated as intended, and repository state shows only `index.html` was modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c47af3bc28832d843a27528f39e1b4)