### PR TITLE
feat: 코트별 게임 종료 버튼 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,6 +88,15 @@
       color: white;
       border-color: var(--accent);
     }
+    .btn.success {
+      background: #047857;
+      color: white;
+      border-color: #047857;
+    }
+    .btn.success:hover {
+      background: #065f46;
+      border-color: #065f46;
+    }
     .btn.icon {
       width: 38px;
       height: 38px;
@@ -585,6 +594,30 @@
       });
     }
 
+    function completeCourtGame(courtId) {
+      const targetCourt = data.courts.find(court => court.id === courtId);
+      if (!targetCourt) return;
+
+      const uniquePlayed = Array.from(new Set(targetCourt.players.filter(Boolean)));
+      if (!uniquePlayed.length) return;
+
+      const nextCounts = { ...(data.participationCounts || {}) };
+      uniquePlayed.forEach(name => {
+        nextCounts[name] = (nextCounts[name] || 0) + 1;
+      });
+
+      if (activeSlot && activeSlot.courtId === courtId) activeSlot = null;
+      selectedParticipant = null;
+
+      persist({
+        ...data,
+        participationCounts: nextCounts,
+        courts: data.courts.map(court =>
+          court.id === courtId ? { ...court, players: ["", "", "", ""] } : court
+        )
+      });
+    }
+
     function clearCourts() {
       activeSlot = null;
       selectedParticipant = null;
@@ -646,6 +679,7 @@
               </div>
               <div style="display:flex; gap:10px; align-items:center;">
                 <div class="badge">${filled}/4</div>
+                <button class="btn success" data-complete-court-id="${court.id}">게임 종료</button>
                 <button class="btn" data-delete-court-id="${court.id}">삭제</button>
               </div>
             </div>
@@ -672,6 +706,9 @@
 
       list.querySelectorAll("[data-delete-court-id]").forEach(btn => {
         btn.addEventListener("click", () => removeCourt(btn.dataset.deleteCourtId));
+      });
+      list.querySelectorAll("[data-complete-court-id]").forEach(btn => {
+        btn.addEventListener("click", () => completeCourtGame(btn.dataset.completeCourtId));
       });
     }
 


### PR DESCRIPTION
### Motivation
- 특정 코트만 게임 종료 처리를 할 수 있도록 하여, 해당 코트에 배치된 인원만 참여 횟수를 증가시키고 해당 코트만 비우는 흐름을 제공하기 위해 변경했습니다.

### Description
- `btn.success` 스타일을 추가해 코트별 종료 버튼을 시각적으로 구분하도록 했습니다.
- `renderCourts()`에 각 코트 카드에 `<button class="btn success" data-complete-court-id="${court.id}">게임 종료</button>`를 추가했습니다.
- 코트별 종료 버튼에 대한 이벤트 바인딩을 추가해 클릭 시 `completeCourtGame(courtId)`를 호출하도록 연결했습니다.
- `completeCourtGame(courtId)` 함수를 추가해 해당 코트에 배치된 고유 플레이어들만 `participationCounts`를 +1 처리하고 해당 코트의 슬롯만 비우도록 구현했으며, 빈 코트는 무시하도록 가드 처리했습니다.

### Testing
- 자동 검사인 `git diff --check`를 실행해 문제가 없음(`pass`)을 확인했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c520a0f84c832dbf0eac34080e8ec4)